### PR TITLE
FIX: fix compilation with libxml2 2.12.0

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -38,6 +38,7 @@
 #include "lxappearance/lxappearance.h"
 
 #include <gdk/gdkx.h>
+#include <libxml/xmlsave.h>
 
 GtkWidget *mainwin = NULL;
 


### PR DESCRIPTION
With libxml2 2.12.0, especially with the commit:
https://gitlab.gnome.org/GNOME/libxml2/-/commit/11a1839ddd67457a68ce938157b3525159a198c8 xmlIndentTreeOutput definition was moved to libxml/xmlsave.h .

Add additional include to src/main.c .

Without this, 
https://github.com/lxde/lxappearance-obconf/commit/63c5dc1b48576cddaf147eb1c46096dacfeaa344
fails with compile with libxml2 2.12.0 as:

```
src/main.c: In function 'plugin_load':
src/main.c:209:5: error: 'xmlIndentTreeOutput' undeclared (first use in this function)
  209 |     xmlIndentTreeOutput = 1;
      |     ^~~~~~~~~~~~~~~~~~~
```